### PR TITLE
Datastore, more hooks, and better typing

### DIFF
--- a/lib/csv_importer.rb
+++ b/lib/csv_importer.rb
@@ -7,6 +7,7 @@ require "csv_importer/version"
 require "csv_importer/csv_reader"
 require "csv_importer/column_definition"
 require "csv_importer/column"
+require "csv_importer/config_interface"
 require "csv_importer/header"
 require "csv_importer/row"
 require "csv_importer/report"
@@ -38,11 +39,12 @@ module CSVImporter
   # Setup DSL and config object
   module ClassMethods
     extend T::Sig
+    include ::CSVImporter::ConfigInterface
     include Dsl
 
     # Class level configuration, as defined by the `Config` class
     # @return [Config] - The class level configuration for the importer
-    sig { returns(Config) }
+    sig { override.returns(Config) }
     def config
       @config = T.let(@config, T.nilable(Config)) unless defined?(@config)
       @config ||= Config.new
@@ -55,9 +57,10 @@ module CSVImporter
   # Instance level config will run against this configurator
   class Configurator
     extend T::Sig
+    include ConfigInterface
     include Dsl
 
-    sig { returns(Config) }
+    sig { override.returns(Config) }
     attr_reader :config
 
     sig { params(config: Config).void }
@@ -99,28 +102,38 @@ module CSVImporter
   end
 
   # Class level configuration for the importer
+  # @!attribute [r] config
+  # @return [Config] - The class level configuration for the importer
   sig { returns(Config) }
   attr_reader :config
 
   # CSV reader to read the CSV file
+  # @!attribute [r] csv
+  # @return [CSVReader] - The CSV reader for the importer
   sig { returns(CSVReader) }
   attr_reader :csv
 
   # Report the result of the import
+  # @!attribute [r] report
+  # @return [Report] - The report for the import
   sig { returns(Report) }
   attr_reader :report
 
   # Storage for data that can be accessed during the import process
+  # @!attribute [r] datastore
+  # @return [T::Hash[Symbol, T.anything]] - The datastore for the import
   sig { returns(T::Hash[Symbol, T.anything]) }
   attr_reader :datastore
 
   # Initialize and return the `Header` for the current CSV file
+  # @return [Header] - The header for the import
   sig { returns(Header) }
   def header
     @header ||= Header.new(column_definitions: config.column_definitions, column_names: csv.header)
   end
 
   # Initialize and return the `Row`s for the current CSV file
+  # @return [T::Array[Row]] - The rows for the import
   sig { returns(T::Array[Row]) }
   def rows
     csv.rows.map.with_index(2) do |row_array, line_number|

--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -58,6 +58,11 @@ module CSVImporter
     sig { returns(T::Boolean) }
     attr_accessor :required
 
+    # @!attribute [rw] virtual
+    # @return [Boolean] whether the column is virtual
+    sig { returns(T::Boolean) }
+    attr_accessor :virtual
+
     # Initialize a new column definition
     # @param name [Symbol, String, nil] the name of the column in the CSV file
     # @param to [Symbol, Proc, nil] the attribute on the model that will be set with the value of the column. If nil,
@@ -70,14 +75,16 @@ module CSVImporter
         name: T.nilable(T.any(String, Symbol)),
         to: ToType,
         as: AsType,
-        required: T::Boolean
+        required: T::Boolean,
+        virtual: T::Boolean
       ).void
     end
-    def initialize(name: nil, to: nil, as: nil, required: false)
+    def initialize(name: nil, to: nil, as: nil, required: false, virtual: false)
       @name = name
       @to = to
       @as = as
       @required = required
+      @virtual = virtual
     end
 
     # Whether the column is required, i.e., the model will raise an error if the column is not present in the CSV file.
@@ -85,6 +92,13 @@ module CSVImporter
     sig { returns(T::Boolean) }
     def required?
       required
+    end
+
+    # Whether the column is virtual, i.e., not present on the associated model and won't be set on the model at all.
+    # @return [Boolean] `true` if the column is virtual, `false` otherwise
+    sig { returns(T::Boolean) }
+    def virtual?
+      virtual
     end
 
     # Attribute on the model that will be set with the value of the column

--- a/lib/csv_importer/column_definition.rb
+++ b/lib/csv_importer/column_definition.rb
@@ -32,6 +32,10 @@ module CSVImporter
   class ColumnDefinition
     extend T::Sig
 
+    ToType = T.type_alias { T.nilable(T.any(Symbol, T.untyped)) }
+    AsNonArrayType = T.type_alias { T.nilable(T.any(Symbol, String, Regexp)) }
+    AsType = T.type_alias { T.nilable(T.any(AsNonArrayType, T::Array[AsNonArrayType])) }
+
     # @!attribute [rw] name
     # @return [String, Symbol, nil] the name of the column in the CSV file
     sig { returns(T.nilable(T.any(String, Symbol))) }
@@ -40,13 +44,13 @@ module CSVImporter
     # @!attribute [rw] to
     # @return [Symbol, T.untyped, nil] the attribute on the model that will be set with the value of the column.
     #  If nil, the name of the column in the CSV file will be used.
-    sig { returns(T.nilable(T.any(Symbol, T.untyped))) }
+    sig { returns(ToType) }
     attr_accessor :to
 
     # @!attribute [rw] as
-    # @return [Symbol, String, Regexp, Array, nil] more complex matching logic for the name of the column in the CSV
-    #   file. If nil, the name of the column in the CSV file will be used.
-    sig { returns(T.nilable(T.any(Symbol, String, Regexp, T::Array[T.any(Symbol, String, Regexp)]))) }
+    # @return [Symbol, String, Regexp, Array<Symbol, String, Regexp>, nil] more complex matching logic for the name
+    #   of the column in the CSV file. If nil, the name of the column in the CSV file will be used.
+    sig { returns(AsType) }
     attr_accessor :as
 
     # @!attribute [rw] required
@@ -64,8 +68,8 @@ module CSVImporter
     sig do
       params(
         name: T.nilable(T.any(String, Symbol)),
-        to: T.nilable(T.any(Symbol, T.untyped)),
-        as: T.nilable(T.any(Symbol, String, Regexp, T.untyped)),
+        to: ToType,
+        as: AsType,
         required: T::Boolean
       ).void
     end
@@ -102,7 +106,7 @@ module CSVImporter
     sig do
       params(
         column_name: T.nilable(String),
-        search_query: T.nilable(T.any(Symbol, String, Regexp, T::Array[T.any(Symbol, String, Regexp)]))
+        search_query: AsType
       ).returns(T::Boolean)
     end
     def match?(column_name, search_query = nil)

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 module CSVImporter

--- a/lib/csv_importer/config.rb
+++ b/lib/csv_importer/config.rb
@@ -31,6 +31,12 @@ module CSVImporter
     sig { returns(T::Array[ColumnDefinition]) }
     attr_accessor :column_definitions
 
+    # The blocks to perform before the import is run, i.e., before any rows are processed whatsoever
+    # @!attribute [rw] before_import_blocks
+    # @return [T::Array[Proc]] the blocks to perform before the import is run
+    sig { returns(T::Array[Proc]) }
+    attr_accessor :before_import_blocks
+
     # The blocks to run after a record is built
     # @!attribute [rw] after_build_blocks
     # @return [T::Array[Proc]] the blocks to run after a record is built
@@ -47,9 +53,18 @@ module CSVImporter
     sig { void }
     def initialize
       @column_definitions = T.let([], T::Array[ColumnDefinition])
+      @before_import_blocks = T.let([], T::Array[Proc])
       @after_build_blocks = T.let([], T::Array[Proc])
       @after_save_blocks = T.let([], T::Array[Proc])
       @when_invalid = T.let(:skip, Symbol)
+    end
+
+    # Add a block to run before the import is run
+    # @param block [Proc] the block to run before the import is run
+    # @note the proc will be added to the config's before_import_blocks array
+    sig { params(block: Proc).void }
+    def before_import(block)
+      @before_import_blocks << block
     end
 
     # Add a block to run after a record is built

--- a/lib/csv_importer/config_interface.rb
+++ b/lib/csv_importer/config_interface.rb
@@ -1,0 +1,18 @@
+# typed: strong
+# frozen_string_literal: true
+
+module CSVImporter
+  # Interface for objects that can provide a `Config`
+  module ConfigInterface
+    extend T::Sig
+    extend T::Helpers
+
+    interface!
+
+    # Return the appropriate configuration for the relevant import
+    # @return [Config] the configuration
+    sig { abstract.returns(Config) }
+    def config
+    end
+  end
+end

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -36,7 +36,7 @@ module CSVImporter
         virtual: T.nilable(T::Boolean)
       ).void
     end
-    def column(name, to: nil, as: nil, required: false , virtual: false)
+    def column(name, to: nil, as: nil, required: false, virtual: false)
       column_definition = ColumnDefinition.new(
         name:, to:, as:, required: required || false, virtual: virtual || false
       )

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -4,12 +4,15 @@ module CSVImporter
   # This Dsl extends a class that includes CSVImporter
   # It is a thin proxy to the Config object
   module Dsl
+    extend T::Sig
+
     # Set the model to which imported data will be mapped
     # @param model_klass [Class] the model to which imported data will be mapped
     def model(model_klass)
       config.model = model_klass
     end
 
+    sig { params(name: Symbol, options: T::Hash[Symbol, T.anything]).void }
     # Define a column for the model
     # @param name [Symbol] the name of the column
     # @param options [Hash] the options for the column
@@ -25,18 +28,28 @@ module CSVImporter
 
     alias_method :identifiers, :identifier
 
+    sig { params(action: Symbol).void }
     # Action to take when a record is invalid
     # @param action [Symbol] the action to take when a record is invalid
     def when_invalid(action)
       config.when_invalid = action
     end
 
+    sig { params(block: Proc).void }
+    # Block to run before the import is run
+    # @param block [Proc] the block to run before the import is run
+    def before_import(&block)
+      config.before_import(block)
+    end
+
+    sig { params(block: Proc).void }
     # Block to run after a record is built
     # @param block [Proc] the block to run after a record is built
     def after_build(&block)
       config.after_build(block)
     end
 
+    sig { params(block: Proc).void }
     # Block to run after a record is saved
     # @param block [Proc] the block to run after a record is saved
     def after_save(&block)

--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -22,19 +22,23 @@ module CSVImporter
     #   the name of the column in the CSV file will be used.
     # @param as [Symbol, String, Regexp, Array, nil] more complex matching logic for the name of the column in the CSV file.
     #   If nil, the name of the column in the CSV file will be used.
-    # @param required [Boolean] whether the column is required
+    # @param required [Boolean] [Optional] whether the column is required, i.e., the importer will raise an error if
+    #   the column is not present in the CSV file. Defaults to false.
+    # @param virtual [Boolean] [Optional] whether the column is virtual, i.e., not present on the associated model and
+    #   won't be set on the model at all. Defaults to false.
     # @param options [Hash] the options for the column
     sig do
       params(
         name: Symbol,
         to: CSVImporter::ColumnDefinition::ToType,
         as: CSVImporter::ColumnDefinition::AsType,
-        required: T.nilable(T::Boolean)
+        required: T.nilable(T::Boolean),
+        virtual: T.nilable(T::Boolean)
       ).void
     end
-    def column(name, to: nil, as: nil, required: false)
+    def column(name, to: nil, as: nil, required: false , virtual: false)
       column_definition = ColumnDefinition.new(
-        name:, to:, as:, required: required || false
+        name:, to:, as:, required: required || false, virtual: virtual || false
       )
       config.column_definitions << column_definition
     end

--- a/lib/csv_importer/header.rb
+++ b/lib/csv_importer/header.rb
@@ -24,20 +24,10 @@ module CSVImporter
     # to an empty array.
     # @param column_names [Array[String]] [Optional] the column names for the importer. Defaults to an empty array.
     sig do
-      params(column_definitions: T::Array[T.any(T::Hash[T.any(Symbol, String), T.untyped], ColumnDefinition)],
-        column_names: T::Array[T.any(String, Symbol)]).void
+      params(column_definitions: T::Array[ColumnDefinition], column_names: T::Array[T.any(String, Symbol)]).void
     end
     def initialize(column_definitions: [], column_names: [])
-      constructed_column_definitions = if column_definitions.first.is_a?(Hash)
-        column_definitions.map do |definition|
-          hash_attributes = T.cast(definition, T::Hash[T.any(Symbol, String), T.untyped])
-          symbolized_hash_attributes = hash_attributes.transform_keys!(&:to_sym)
-          ColumnDefinition.new(**symbolized_hash_attributes)
-        end
-      else
-        T.cast(column_definitions, T::Array[ColumnDefinition])
-      end
-      @column_definitions = T.let(constructed_column_definitions, T::Array[ColumnDefinition])
+      @column_definitions = T.let(column_definitions, T::Array[ColumnDefinition])
 
       @column_names = column_names
     end

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -140,7 +140,11 @@ module CSVImporter
           # can't dup Symbols, Integer etc...
         end
 
-        next if column.definition.nil?
+        definition = column.definition
+
+        next unless definition
+
+        next if definition.virtual?
 
         set_attribute(model, column, value)
       end

--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -45,6 +45,11 @@ module CSVImporter
     sig { returns(T::Boolean) }
     attr_accessor :skip
 
+    # @!attribute [r] datastore
+    # @return [Hash<Symbol, T.anything>] Storage for data that can be accessed during the import process
+    sig { returns(T::Hash[Symbol, T.anything]) }
+    attr_reader :datastore
+
     # Initialize a new Row
     # @param line_number [Integer] The line number in the CSV file
     # @param header [Header, nil] The CSV header
@@ -53,6 +58,7 @@ module CSVImporter
     # @param identifiers [Array<Symbol>, Proc, nil] Identifiers to find existing records
     # @param after_build_blocks [Array<Proc>] Blocks to run after building the model
     # @param skip [Boolean] Whether to skip this row
+    # @param datastore [Hash<Symbol, T.anything>] Storage for data that can be accessed during the import process
     sig do
       params(
         line_number: Integer,
@@ -61,11 +67,12 @@ module CSVImporter
         model_klass: T.untyped,
         identifiers: T.nilable(T.any(T::Array[Symbol], Proc)),
         after_build_blocks: T::Array[Proc],
-        skip: T::Boolean
+        skip: T::Boolean,
+        datastore: T::Hash[Symbol, T.anything]
       ).void
     end
     def initialize(line_number:, header: nil, row_array: [], model_klass: nil, identifiers: nil,
-      after_build_blocks: [], skip: false)
+      after_build_blocks: [], skip: false, datastore: {})
       @header = T.let(header, T.nilable(Header))
       @line_number = T.let(line_number, Integer)
       @row_array = T.let(row_array, T::Array[String])
@@ -75,6 +82,7 @@ module CSVImporter
       @skip = T.let(skip, T::Boolean)
       @model = T.let(nil, T.untyped)
       @csv_attributes = T.let(nil, T.nilable(T::Hash[T.any(String, Symbol), T.nilable(String)]))
+      @datastore = T.let(datastore, T::Hash[Symbol, T.anything])
     end
 
     # Check if this row should be skipped


### PR DESCRIPTION
### Datastore and hooks
Add support for `datastore` as simple KV store to avoid any overriding initialization logic in the importer. Support this functionaity with a `before_import_blocks` hooks that allows for arbitrary code to be run prior to persistence, which is particularly useful for preloads

### Virtual attributes
Adds support for virtual columns using the `virtual: true`. These are columns that should be read in, but shouldn't actually be set are the model. This allows them to easily be referenced in the import, without actually attempting to set attributes on the model that don't exist. Note that this is distinct from a Rails virtual attribute in ActiveModel, and its name is thus subject to change

### Typing
Improve typing by creating `ConfigInterface` and using that to add full support for typing to the application with coverage for `Dsl` as well. A few methods are still left without clear typing / documentation, as the signature continues to be improved for those

**Appropriate specs are added to ensure this new functionality works as expected**