### PR TITLE
Improve datastore and add constructor parameter access in hooks

### DIFF
--- a/lib/csv_importer/dsl.rb
+++ b/lib/csv_importer/dsl.rb
@@ -58,8 +58,26 @@ module CSVImporter
       config.when_invalid = action
     end
 
-    # Block to run before the import is run
-    # @param block [Proc] the block to run before the import is run
+    # Define a block to run before the import process starts.
+    # This runs before any rows are processed, making it ideal for:
+    # - Preloading reference data needed for lookups
+    # - Setting up context for the import
+    # - Preparing data structures to optimize performance
+    #
+    # The block has access to the datastore, which contains any custom parameters
+    # passed during initialization.
+    #
+    # @example Preload data for efficient lookups
+    #   before_import do
+    #     # Access constructor parameters
+    #     company_id = datastore[:company_id]
+    #
+    #     # Preload data for lookups
+    #     employees = Employee.where(company_id: company_id).all
+    #     datastore[:employee_lookup] = employees.index_by(&:email)
+    #   end
+    #
+    # @param block [Proc] A block to run before the import starts
     sig { params(block: Proc).void }
     def before_import(&block)
       config.before_import(block)

--- a/lib/csv_importer/version.rb
+++ b/lib/csv_importer/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module CSVImporter
-  VERSION = '0.0.2'
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
p### TL;DR

Improved datastore functionality to make constructor parameters accessible in hooks and enhanced documentation.

### What changed?

- Refactored the initialization process to categorize parameters into three groups:
  - CSVReader options (content, file, path)
  - Config options that match config object attributes
  - Other options that are stored in the datastore
- Moved the datastore attribute declaration earlier in the code for better visibility
- Enhanced documentation for the datastore and before_import hook with examples
- Added a comprehensive test case demonstrating how to access constructor parameters in hooks
- Bumped version from 0.0.2 to 0.0.3

### How to test?

1. Create an importer that accepts custom parameters:
   ```ruby
   class MyImporter
     include CSVImporter
     
     model User
     
     column :name
     
     before_import do
       # Access custom parameter
       puts "Using domain: #{datastore[:domain]}"
     end
     
     after_build do |user|
       user.email = "#{user.name}@#{datastore[:domain]}"
     end
   end
   ```

2. Initialize with custom parameters:
   ```ruby
   importer = MyImporter.new(
     content: "name\nJohn\nJane",
     domain: "example.com"
   )
   importer.run!
   ```

3. Verify that the domain parameter is accessible in hooks and used correctly.

### Why make this change?

This change makes the importer more flexible by allowing users to pass custom parameters during initialization that can be accessed in hooks. This is particularly useful for:

- Providing context-specific data to the import process
- Preloading reference data for lookups
- Configuring behavior based on runtime parameters

The improved documentation and examples make it clearer how to use this feature effectively.